### PR TITLE
Makefile: use php in coverage target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ tests:
 .PHONY: coverage
 coverage:
 ifdef GITHUB_ACTION
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage coverage.xml --coverage-src src tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage coverage.xml --coverage-src src tests/Cases
 else
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage coverage.html --coverage-src src tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage coverage.html --coverage-src src tests/Cases
 endif


### PR DESCRIPTION
## Summary
- replace `-p phpdbg` with `-p php` in the `coverage` target
- keep the existing GitHub Actions and local coverage outputs unchanged

## Motivation
This repo is part of contributte/contributte#73, which tracks removing `phpdbg` from Contributte coverage targets.

## Changes
- update both `coverage` target branches in `Makefile`
- verify the resolved command with `make -n coverage`

## Testing
- [x] `make -n coverage`
- [ ] CI passes
- [ ] Manual verification (if applicable)