### PR TITLE
Add Inertia.js integration for Nette applications

### DIFF
--- a/.docs/README.md
+++ b/.docs/README.md
@@ -8,6 +8,74 @@ composer require contributte/ui
 
 ## Usage
 
+### Inertia
+
+Register the extension:
+
+```neon
+extensions:
+	inertia: Contributte\UI\DI\InertiaExtension
+
+inertia:
+	manifest: %wwwDir%/dist/manifest.json
+	# rootId: app
+	# template: %appDir%/UI/@Templates/@inertia.latte
+```
+
+Use the presenter trait:
+
+```php
+use Contributte\UI\Inertia\Presenter\TInertiaPresenter;
+use Nette\Application\UI\Presenter;
+
+abstract class BasePresenter extends Presenter
+{
+	use TInertiaPresenter;
+}
+```
+
+Render an Inertia page from a presenter:
+
+```php
+final class DashboardPresenter extends BasePresenter
+{
+	public function renderDefault(): void
+	{
+		$this->inertia('Dashboard/Index', [
+			'user' => ['name' => 'Felix'],
+			'stats' => fn (): array => [1, 2, 3],
+		]);
+	}
+}
+```
+
+If you want a custom root template, point the extension to your own Latte file and use the provided helpers:
+
+```latte
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	{vitecss 'assets/js/app.ts'}
+	{vitejs 'assets/js/app.ts'}
+	{=inertiaHead()}
+</head>
+<body>
+	{=inertia($page)}
+</body>
+</html>
+```
+
+The integration supports:
+
+- initial HTML bootstrap with `data-page`
+- JSON Inertia responses via `X-Inertia: true`
+- asset version checks via `manifest`
+- `409 + X-Inertia-Location` on stale assets
+- partial reload filtering via `X-Inertia-Partial-*`
+- session-backed validation errors via `inertiaErrors()`
+
 ### Bundler
 
 ```neon

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
     "latte/latte": "^3.0.12",
     "nette/application": "^3.2",
     "nette/di": "^3.1.8",
+    "nette/http": "^3.3",
     "nette/utils": "^4.0.3"
   },
   "require-dev": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -14,6 +14,3 @@ parameters:
 	paths:
 		- src
 		- .docs
-
-	ignoreErrors:
-		- '#Parameter \#1 \$callbacks of static method Nette\\Utils\\Arrays::invoke\(\) expects#'

--- a/src/DI/InertiaExtension.php
+++ b/src/DI/InertiaExtension.php
@@ -1,0 +1,68 @@
+<?php declare(strict_types = 1);
+
+namespace Contributte\UI\DI;
+
+use Contributte\UI\Inertia\ErrorStore;
+use Contributte\UI\Inertia\Inertia;
+use Contributte\UI\Inertia\LatteExtension;
+use Nette\DI\CompilerExtension;
+use Nette\DI\Definitions\FactoryDefinition;
+use Nette\Schema\Expect;
+use Nette\Schema\Schema;
+use stdClass;
+
+/**
+ * @method stdClass getConfig()
+ */
+final class InertiaExtension extends CompilerExtension
+{
+
+	public function getConfigSchema(): Schema
+	{
+		return Expect::structure([
+			'version' => Expect::string()->nullable()->dynamic()->default(null),
+			'manifest' => Expect::string()->nullable()->default(null),
+			'rootId' => Expect::string('app'),
+			'template' => Expect::string(__DIR__ . '/../Inertia/Template/page.latte'),
+			'sessionSection' => Expect::string('contributte.ui.inertia'),
+		]);
+	}
+
+	public function loadConfiguration(): void
+	{
+		$config = $this->getConfig();
+		$builder = $this->getContainerBuilder();
+
+		$builder->addDefinition($this->prefix('inertia'))
+			->setFactory(Inertia::class, [
+				'version' => $config->version,
+				'manifest' => $config->manifest,
+				'rootId' => $config->rootId,
+				'templateFile' => $config->template,
+			]);
+
+		$builder->addDefinition($this->prefix('errorStore'))
+			->setFactory(ErrorStore::class, [
+				'section' => $config->sessionSection,
+			]);
+
+		$builder->addDefinition($this->prefix('latteExtension'))
+			->setFactory(LatteExtension::class);
+	}
+
+	public function beforeCompile(): void
+	{
+		$builder = $this->getContainerBuilder();
+
+		if (!$builder->hasDefinition('latte.latteFactory')) {
+			return;
+		}
+
+		$definition = $builder->getDefinition('latte.latteFactory');
+		assert($definition instanceof FactoryDefinition);
+
+		$definition->getResultDefinition()
+			->addSetup('addExtension', [$builder->getDefinition($this->prefix('latteExtension'))]);
+	}
+
+}

--- a/src/Inertia/ErrorStore.php
+++ b/src/Inertia/ErrorStore.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types = 1);
+
+namespace Contributte\UI\Inertia;
+
+use Nette\Http\Session;
+
+final class ErrorStore
+{
+
+	public function __construct(
+		private readonly Session $session,
+		private readonly string $section = 'contributte.ui.inertia',
+	)
+	{
+	}
+
+	/**
+	 * @param array<string, mixed> $errors
+	 */
+	public function flash(array $errors, ?string $bag = null): void
+	{
+		$bag ??= 'default';
+
+		$section = $this->session->getSection($this->section);
+		/** @var array<string, array<string, mixed>> $current */
+		$current = $section->get('errors') ?? [];
+		$current[$bag] = $errors;
+		$section->set('errors', $current, '30 seconds');
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	public function pull(?string $bag = null): array
+	{
+		$section = $this->session->getSection($this->section);
+		/** @var array<string, array<string, mixed>> $errors */
+		$errors = $section->get('errors') ?? [];
+		$section->remove('errors');
+
+		if ($errors === []) {
+			return [];
+		}
+
+		if ($bag !== null) {
+			if (isset($errors['default'])) {
+				return [$bag => $errors['default']];
+			}
+
+			return isset($errors[$bag]) ? [$bag => $errors[$bag]] : [];
+		}
+
+		if (isset($errors['default']) && count($errors) === 1) {
+			return $errors['default'];
+		}
+
+		return $errors;
+	}
+
+}

--- a/src/Inertia/Inertia.php
+++ b/src/Inertia/Inertia.php
@@ -1,0 +1,194 @@
+<?php declare(strict_types = 1);
+
+namespace Contributte\UI\Inertia;
+
+use Closure;
+use JsonSerializable;
+use Nette\Http\IRequest;
+use Nette\Http\UrlScript;
+use UnitEnum;
+
+final class Inertia
+{
+
+	private ?string $resolvedVersion = null;
+
+	private bool $versionResolved = false;
+
+	public function __construct(
+		private readonly ?string $version = null,
+		private readonly ?string $manifest = null,
+		private readonly string $rootId = 'app',
+		private readonly string $templateFile = __DIR__ . '/Template/page.latte',
+	)
+	{
+	}
+
+	public function getRootId(): string
+	{
+		return $this->rootId;
+	}
+
+	public function getTemplateFile(): string
+	{
+		return $this->templateFile;
+	}
+
+	public function getVersion(): ?string
+	{
+		if ($this->versionResolved) {
+			return $this->resolvedVersion;
+		}
+
+		$this->versionResolved = true;
+
+		if ($this->version !== null) {
+			return $this->resolvedVersion = $this->version;
+		}
+
+		if ($this->manifest !== null && is_file($this->manifest)) {
+			$hash = hash_file('xxh128', $this->manifest);
+
+			if ($hash === false) {
+				$md5 = md5_file($this->manifest);
+				$hash = $md5 === false ? null : $md5;
+			}
+
+			return $this->resolvedVersion = $hash;
+		}
+
+		return $this->resolvedVersion = null;
+	}
+
+	public function isInertiaRequest(IRequest $httpRequest): bool
+	{
+		return $httpRequest->getHeader('X-Inertia') === 'true';
+	}
+
+	public function isVersionMismatch(IRequest $httpRequest): bool
+	{
+		$version = $this->getVersion();
+
+		if ($version === null) {
+			return false;
+		}
+
+		return $httpRequest->getHeader('X-Inertia-Version') !== $version;
+	}
+
+	/**
+	 * @param array<string, mixed> $props
+	 */
+	public function createPage(IRequest $httpRequest, string $component, array $props): Page
+	{
+		$props = $this->filterPartialProps($httpRequest, $component, $props);
+		$props = $this->resolveProps($props);
+
+		return new Page(
+			component: $component,
+			props: $props,
+			url: $this->resolveUrl($httpRequest->getUrl()),
+			version: $this->getVersion(),
+		);
+	}
+
+	private function resolveUrl(UrlScript $url): string
+	{
+		$relativeUrl = $url->getRelativeUrl();
+
+		return $relativeUrl !== '' ? '/' . ltrim($relativeUrl, '/') : '/';
+	}
+
+	/**
+	 * @param array<string, mixed> $props
+	 * @return array<string, mixed>
+	 */
+	private function filterPartialProps(IRequest $httpRequest, string $component, array $props): array
+	{
+		if ($httpRequest->getHeader('X-Inertia-Partial-Component') !== $component) {
+			return $props;
+		}
+
+		$only = $this->parseHeaderList($httpRequest->getHeader('X-Inertia-Partial-Data'));
+		$except = $this->parseHeaderList($httpRequest->getHeader('X-Inertia-Partial-Except'));
+
+		if ($only !== []) {
+			$filtered = [];
+
+			foreach ($only as $key) {
+				if (array_key_exists($key, $props)) {
+					$filtered[$key] = $props[$key];
+				}
+			}
+
+			if (array_key_exists('errors', $props)) {
+				$filtered['errors'] = $props['errors'];
+			}
+
+			$props = $filtered;
+		}
+
+		if ($except !== []) {
+			foreach ($except as $key) {
+				if ($key === 'errors') {
+					continue;
+				}
+
+				unset($props[$key]);
+			}
+		}
+
+		return $props;
+	}
+
+	/**
+	 * @param array<string, mixed> $props
+	 * @return array<string, mixed>
+	 */
+	private function resolveProps(array $props): array
+	{
+		foreach ($props as $key => $value) {
+			$props[$key] = $this->resolveValue($value);
+		}
+
+		return $props;
+	}
+
+	private function resolveValue(mixed $value): mixed
+	{
+		if ($value instanceof Closure) {
+			$value = $value();
+		}
+
+		if ($value instanceof JsonSerializable) {
+			$value = $value->jsonSerialize();
+		}
+
+		if ($value instanceof UnitEnum) {
+			return $value instanceof \BackedEnum ? $value->value : $value->name;
+		}
+
+		if (is_array($value)) {
+			foreach ($value as $key => $item) {
+				$value[$key] = $this->resolveValue($item);
+			}
+
+			return $value;
+		}
+
+		return $value;
+	}
+
+	/**
+	 * @return list<string>
+	 */
+	private function parseHeaderList(?string $value): array
+	{
+		if ($value === null || trim($value) === '') {
+			return [];
+		}
+
+		return array_values(array_filter(array_map(static fn (string $item): string => trim($item), explode(',', $value))));
+	}
+
+}

--- a/src/Inertia/LatteExtension.php
+++ b/src/Inertia/LatteExtension.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types = 1);
+
+namespace Contributte\UI\Inertia;
+
+use Latte\Extension;
+use Latte\Runtime\Html;
+use Nette\Utils\Json;
+
+final class LatteExtension extends Extension
+{
+
+	public function __construct(
+		private readonly Inertia $inertia,
+	)
+	{
+	}
+
+	/**
+	 * @return array<string, callable>
+	 */
+	public function getFunctions(): array
+	{
+		return [
+			'inertia' => fn (Page $page): Html => $this->renderRoot($page),
+			'inertiaHead' => static fn (): Html => new Html(''),
+		];
+	}
+
+	private function renderRoot(Page $page): Html
+	{
+		$payload = htmlspecialchars(Json::encode($page->toArray()), ENT_QUOTES, 'UTF-8');
+
+		return new Html(sprintf('<div id="%s" data-page="%s"></div>', htmlspecialchars($this->inertia->getRootId(), ENT_QUOTES, 'UTF-8'), $payload));
+	}
+
+}

--- a/src/Inertia/LocationResponse.php
+++ b/src/Inertia/LocationResponse.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types = 1);
+
+namespace Contributte\UI\Inertia;
+
+use Nette\Application\Response;
+use Nette\Http\IRequest;
+use Nette\Http\IResponse;
+
+final class LocationResponse implements Response
+{
+
+	public function __construct(
+		private readonly string $url,
+	)
+	{
+	}
+
+	public function send(IRequest $httpRequest, IResponse $httpResponse): void
+	{
+		$httpResponse->setCode(IResponse::S409_Conflict);
+		$httpResponse->setHeader('X-Inertia-Location', $this->url);
+	}
+
+}

--- a/src/Inertia/Page.php
+++ b/src/Inertia/Page.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types = 1);
+
+namespace Contributte\UI\Inertia;
+
+use JsonSerializable;
+
+final class Page implements JsonSerializable
+{
+
+	/**
+	 * @param array<string, mixed> $props
+	 */
+	public function __construct(
+		public readonly string $component,
+		public readonly array $props,
+		public readonly string $url,
+		public readonly ?string $version,
+		public readonly bool $clearHistory = false,
+		public readonly bool $encryptHistory = false,
+	)
+	{
+	}
+
+	/**
+	 * @return array{component: string, props: array<string, mixed>, url: string, version: string|null, clearHistory: bool, encryptHistory: bool}
+	 */
+	public function toArray(): array
+	{
+		return [
+			'component' => $this->component,
+			'props' => $this->props,
+			'url' => $this->url,
+			'version' => $this->version,
+			'clearHistory' => $this->clearHistory,
+			'encryptHistory' => $this->encryptHistory,
+		];
+	}
+
+	/**
+	 * @return array{component: string, props: array<string, mixed>, url: string, version: string|null, clearHistory: bool, encryptHistory: bool}
+	 */
+	public function jsonSerialize(): array
+	{
+		return $this->toArray();
+	}
+
+}

--- a/src/Inertia/Presenter/TInertiaPresenter.php
+++ b/src/Inertia/Presenter/TInertiaPresenter.php
@@ -1,0 +1,106 @@
+<?php declare(strict_types = 1);
+
+namespace Contributte\UI\Inertia\Presenter;
+
+use Contributte\UI\Inertia\ErrorStore;
+use Contributte\UI\Inertia\Inertia;
+use Contributte\UI\Inertia\LocationResponse;
+use Nette\Http\IResponse;
+
+trait TInertiaPresenter
+{
+
+	private Inertia $inertia;
+
+	private ErrorStore $inertiaErrorStore;
+
+	/** @var array<string, mixed> */
+	private array $inertiaSharedProps = [];
+
+	public function injectInertia(Inertia $inertia, ErrorStore $inertiaErrorStore): void
+	{
+		$this->inertia = $inertia;
+		$this->inertiaErrorStore = $inertiaErrorStore;
+	}
+
+	public function redirectUrl(string $url, ?int $httpCode = null): void
+	{
+		if ($httpCode === null && $this->inertia->isInertiaRequest($this->getHttpRequest()) && !$this->getHttpRequest()->isMethod('GET')) {
+			$httpCode = IResponse::S303_PostGet;
+		}
+
+		parent::redirectUrl($url, $httpCode);
+	}
+
+	/**
+	 * @param array<string, mixed> $props
+	 */
+	protected function inertia(string $component, array $props = []): void
+	{
+		$httpRequest = $this->getHttpRequest();
+		$httpResponse = $this->getHttpResponse();
+		$httpResponse->setHeader('Vary', 'X-Inertia');
+
+		if ($this->inertia->isInertiaRequest($httpRequest) && $httpRequest->isMethod('GET') && $this->inertia->isVersionMismatch($httpRequest)) {
+			$this->sendResponse(new LocationResponse($httpRequest->getUrl()->getAbsoluteUrl()));
+		}
+
+		$props = array_merge(
+			['errors' => $this->inertiaErrorStore->pull($httpRequest->getHeader('X-Inertia-Error-Bag'))],
+			$this->getInertiaSharedProps(),
+			$this->inertiaSharedProps,
+			$props,
+		);
+
+		$page = $this->inertia->createPage($httpRequest, $component, $props);
+
+		if ($this->inertia->isInertiaRequest($httpRequest)) {
+			$httpResponse->setHeader('X-Inertia', 'true');
+			$this->sendJson($page);
+		}
+
+		$this->setLayout(false);
+		$this->template->setFile($this->inertia->getTemplateFile());
+		$this->template->page = $page;
+	}
+
+	/**
+	 * @param array<string, mixed> $errors
+	 */
+	protected function inertiaErrors(array $errors, ?string $bag = null): void
+	{
+		$this->inertiaErrorStore->flash($errors, $bag);
+	}
+
+	/**
+	 * @param array<string, mixed>|string $key
+	 */
+	protected function inertiaShare(array|string $key, mixed $value = null): void
+	{
+		if (is_array($key)) {
+			$this->inertiaSharedProps = array_merge($this->inertiaSharedProps, $key);
+
+			return;
+		}
+
+		$this->inertiaSharedProps[$key] = $value;
+	}
+
+	protected function inertiaLocation(string $url): void
+	{
+		if (!$this->inertia->isInertiaRequest($this->getHttpRequest())) {
+			$this->redirectUrl($url);
+		}
+
+		$this->sendResponse(new LocationResponse($url));
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	protected function getInertiaSharedProps(): array
+	{
+		return [];
+	}
+
+}

--- a/src/Inertia/Template/page.latte
+++ b/src/Inertia/Template/page.latte
@@ -1,0 +1,12 @@
+{varType Contributte\UI\Inertia\Page $page}
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	{=inertiaHead()}
+</head>
+<body>
+	{=inertia($page)}
+</body>
+</html>

--- a/tests/Cases/Inertia/ErrorStore.phpt
+++ b/tests/Cases/Inertia/ErrorStore.phpt
@@ -1,0 +1,58 @@
+<?php declare(strict_types = 1);
+
+use Contributte\Tester\Toolkit;
+use Contributte\UI\Inertia\ErrorStore;
+use Nette\Http\Request;
+use Nette\Http\Session;
+use Nette\Http\UrlScript;
+use Tester\Assert;
+use Tests\Fixtures\Inertia\TestHttpResponse;
+
+require_once __DIR__ . '/../../bootstrap.php';
+
+function prepareSessionEnvironment(): void
+{
+	if (session_status() === PHP_SESSION_ACTIVE) {
+		session_write_close();
+	}
+
+	session_id('');
+	session_name('ui_inertia_' . uniqid());
+}
+
+Toolkit::test(function (): void {
+	prepareSessionEnvironment();
+
+	$session = new Session(new Request(new UrlScript('https://example.com', '/index.php')), new TestHttpResponse());
+	$errorStore = new ErrorStore($session, 'tests.inertia');
+
+	$errorStore->flash(['email' => 'Required']);
+	Assert::same(['email' => 'Required'], $errorStore->pull());
+	Assert::same([], $errorStore->pull());
+
+	if ($session->isStarted()) {
+
+		$session->destroy();
+	}
+
+	$session->close();
+	session_id('');
+});
+
+Toolkit::test(function (): void {
+	prepareSessionEnvironment();
+
+	$session = new Session(new Request(new UrlScript('https://example.com', '/index.php')), new TestHttpResponse());
+	$errorStore = new ErrorStore($session, 'tests.inertia');
+
+	$errorStore->flash(['email' => 'Required']);
+	Assert::same(['createUser' => ['email' => 'Required']], $errorStore->pull('createUser'));
+
+	if ($session->isStarted()) {
+
+		$session->destroy();
+	}
+
+	$session->close();
+	session_id('');
+});

--- a/tests/Cases/Inertia/Inertia.phpt
+++ b/tests/Cases/Inertia/Inertia.phpt
@@ -1,0 +1,96 @@
+<?php declare(strict_types = 1);
+
+use Contributte\Tester\Toolkit;
+use Contributte\UI\Inertia\Inertia;
+use Contributte\UI\Inertia\Page;
+use Nette\Http\Request;
+use Nette\Http\UrlScript;
+use Tester\Assert;
+
+require_once __DIR__ . '/../../bootstrap.php';
+
+Toolkit::test(function (): void {
+	$inertia = new Inertia(version: 'build-123', rootId: 'frontend', templateFile: '/tmp/root.latte');
+	$request = new Request(new UrlScript('https://example.com/articles?foo=1', '/index.php'));
+
+	$page = $inertia->createPage($request, 'Articles/Index', ['articles' => ['a', 'b']]);
+
+	Assert::type(Page::class, $page);
+	Assert::same('frontend', $inertia->getRootId());
+	Assert::same('/tmp/root.latte', $inertia->getTemplateFile());
+	Assert::same('build-123', $page->version);
+	Assert::same('/articles?foo=1', $page->url);
+	Assert::same('Articles/Index', $page->component);
+	Assert::same(['articles' => ['a', 'b']], $page->props);
+	Assert::same([
+		'component' => 'Articles/Index',
+		'props' => ['articles' => ['a', 'b']],
+		'url' => '/articles?foo=1',
+		'version' => 'build-123',
+		'clearHistory' => false,
+		'encryptHistory' => false,
+	], $page->toArray());
+});
+
+Toolkit::test(function (): void {
+	$state = (object) ['counter' => 0];
+	$inertia = new Inertia(version: 'v1');
+	$request = new Request(
+		new UrlScript('https://example.com/users', '/index.php'),
+		headers: [
+			'X-Inertia-Partial-Component' => 'Users/Index',
+			'X-Inertia-Partial-Data' => 'users',
+		],
+	);
+
+	$page = $inertia->createPage($request, 'Users/Index', [
+		'users' => function () use ($state): array {
+			$state->counter++;
+
+			return ['Felix'];
+		},
+		'companies' => function () use ($state): array {
+			$state->counter += 100;
+
+			return ['Contributte'];
+		},
+		'errors' => ['name' => 'Required'],
+	]);
+
+	Assert::same(1, $state->counter);
+	Assert::same([
+		'users' => ['Felix'],
+		'errors' => ['name' => 'Required'],
+	], $page->props);
+});
+
+Toolkit::test(function (): void {
+	$inertia = new Inertia(version: 'v1');
+	$request = new Request(
+		new UrlScript('https://example.com/users', '/index.php'),
+		headers: [
+			'X-Inertia-Partial-Component' => 'Users/Index',
+			'X-Inertia-Partial-Except' => 'filters',
+		],
+	);
+
+	$page = $inertia->createPage($request, 'Users/Index', [
+		'users' => ['Felix'],
+		'filters' => ['active' => true],
+		'errors' => ['name' => 'Required'],
+	]);
+
+	Assert::same([
+		'users' => ['Felix'],
+		'errors' => ['name' => 'Required'],
+	], $page->props);
+});
+
+Toolkit::test(function (): void {
+	$inertia = new Inertia(version: 'v1');
+	$request = new Request(new UrlScript('https://example.com', '/index.php'), headers: ['X-Inertia-Version' => 'old']);
+
+	Assert::true($inertia->isVersionMismatch($request));
+	Assert::false($inertia->isVersionMismatch(new Request(new UrlScript('https://example.com', '/index.php'), headers: ['X-Inertia-Version' => 'v1'])));
+	Assert::true($inertia->isInertiaRequest(new Request(new UrlScript('https://example.com', '/index.php'), headers: ['X-Inertia' => 'true'])));
+});

--- a/tests/Cases/Inertia/LatteExtension.phpt
+++ b/tests/Cases/Inertia/LatteExtension.phpt
@@ -1,0 +1,34 @@
+<?php declare(strict_types = 1);
+
+use Contributte\Tester\Toolkit;
+use Contributte\UI\Inertia\Inertia;
+use Contributte\UI\Inertia\LatteExtension;
+use Contributte\UI\Inertia\Page;
+use Latte\Engine;
+use Latte\Loaders\StringLoader;
+use Tester\Assert;
+
+require_once __DIR__ . '/../../bootstrap.php';
+
+Toolkit::test(function (): void {
+	$engine = new Engine();
+	$engine->setLoader(new StringLoader());
+	$engine->addExtension(new LatteExtension(new Inertia(rootId: 'spa-root')));
+
+	$output = $engine->renderToString('{=inertia($page)}', [
+		'page' => new Page('Dashboard', ['message' => 'Hello "Inertia"'], '/dashboard', 'v1'),
+	]);
+
+	Assert::contains('id="spa-root"', $output);
+	Assert::contains('data-page="', $output);
+	Assert::contains('&quot;component&quot;:&quot;Dashboard&quot;', $output);
+	Assert::contains('&quot;message&quot;:&quot;Hello \\&quot;Inertia\\&quot;&quot;', $output);
+});
+
+Toolkit::test(function (): void {
+	$engine = new Engine();
+	$engine->setLoader(new StringLoader());
+	$engine->addExtension(new LatteExtension(new Inertia()));
+
+	Assert::same('', $engine->renderToString('{=inertiaHead()}'));
+});

--- a/tests/Cases/Inertia/PresenterTrait.phpt
+++ b/tests/Cases/Inertia/PresenterTrait.phpt
@@ -1,0 +1,177 @@
+<?php declare(strict_types = 1);
+
+use Contributte\Tester\Toolkit;
+use Contributte\UI\Inertia\ErrorStore;
+use Contributte\UI\Inertia\Inertia;
+use Contributte\UI\Inertia\LocationResponse;
+use Nette\Application\AbortException;
+use Nette\Application\Responses\JsonResponse;
+use Nette\Application\Responses\RedirectResponse;
+use Nette\Http\Request;
+use Nette\Http\Session;
+use Nette\Http\UrlScript;
+use Tester\Assert;
+use Tests\Fixtures\Inertia\TestHttpResponse;
+use Tests\Fixtures\Inertia\TestPresenter;
+
+require_once __DIR__ . '/../../bootstrap.php';
+
+function prepareSessionEnvironment(): void
+{
+	if (session_status() === PHP_SESSION_ACTIVE) {
+		session_write_close();
+	}
+
+	session_id('');
+	session_name('ui_inertia_' . uniqid());
+}
+
+/**
+ * @return array{0: TestPresenter, 1: TestHttpResponse, 2: Request, 3: Session}
+ */
+function createPresenter(Request $request, Inertia $inertia): array
+{
+	$response = new TestHttpResponse();
+	$session = new Session($request, $response);
+	$presenter = new TestPresenter();
+	$presenter->injectPrimary($request, $response, null, null, $session);
+	$presenter->injectInertia($inertia, new ErrorStore($session, 'tests.inertia.presenter'));
+
+	return [$presenter, $response, $request, $session];
+}
+
+Toolkit::test(function (): void {
+	prepareSessionEnvironment();
+
+	$request = new Request(
+		new UrlScript('https://example.com/dashboard?tab=users', '/index.php'),
+		headers: [
+			'X-Inertia' => 'true',
+			'X-Inertia-Version' => 'v1',
+		],
+	);
+
+	[$presenter, $response, , $session] = createPresenter($request, new Inertia(version: 'v1'));
+	$presenter->setSharedProps(['shared' => 'yes']);
+	$presenter->shareInertia('auth', ['user' => 'Felix']);
+
+	Assert::exception(fn () => $presenter->runInertia('Dashboard', ['stats' => fn (): array => [1, 2, 3]]), AbortException::class);
+
+	$captured = $presenter->getCapturedResponse();
+	Assert::type(JsonResponse::class, $captured);
+	assert($captured instanceof JsonResponse);
+	Assert::same('X-Inertia', $response->getHeader('Vary'));
+	Assert::same('true', $response->getHeader('X-Inertia'));
+
+	$payload = $captured->getPayload();
+	Assert::same('Dashboard', $payload->component);
+	Assert::same('/dashboard?tab=users', $payload->url);
+	Assert::same('v1', $payload->version);
+	Assert::same([
+		'errors' => [],
+		'shared' => 'yes',
+		'auth' => ['user' => 'Felix'],
+		'stats' => [1, 2, 3],
+	], $payload->props);
+
+	$session->close();
+	session_id('');
+});
+
+Toolkit::test(function (): void {
+	prepareSessionEnvironment();
+
+	$request = new Request(new UrlScript('https://example.com/home', '/index.php'));
+
+	[$presenter, , , $session] = createPresenter($request, new Inertia(version: 'v1'));
+
+	Assert::exception(fn () => $presenter->triggerLocation('/login'), AbortException::class);
+
+	$captured = $presenter->getCapturedResponse();
+	Assert::type(RedirectResponse::class, $captured);
+	assert($captured instanceof RedirectResponse);
+	Assert::same('/login', $captured->getUrl());
+	Assert::same(302, $captured->getCode());
+
+	$session->close();
+	session_id('');
+});
+
+Toolkit::test(function (): void {
+	prepareSessionEnvironment();
+
+	$request = new Request(
+		new UrlScript('https://example.com/users', '/index.php'),
+		headers: [
+			'X-Inertia' => 'true',
+			'X-Inertia-Version' => 'old',
+		],
+	);
+
+	[$presenter, $response, $httpRequest, $session] = createPresenter($request, new Inertia(version: 'v2'));
+
+	Assert::exception(fn () => $presenter->runInertia('Users/Index'), AbortException::class);
+
+	$captured = $presenter->getCapturedResponse();
+	Assert::type(LocationResponse::class, $captured);
+	assert($captured instanceof LocationResponse);
+
+	$captured->send($httpRequest, $response);
+	Assert::same(409, $response->getCode());
+	Assert::same('https://example.com/users', $response->getHeader('X-Inertia-Location'));
+
+	$session->close();
+	session_id('');
+});
+
+Toolkit::test(function (): void {
+	prepareSessionEnvironment();
+
+	$request = new Request(
+		new UrlScript('https://example.com/form', '/index.php'),
+		post: ['name' => ''],
+		headers: ['X-Inertia' => 'true'],
+		method: 'POST',
+	);
+
+	[$presenter, , , $session] = createPresenter($request, new Inertia(version: 'v1'));
+
+	Assert::exception(fn () => $presenter->triggerRedirect('/form'), AbortException::class);
+
+	$captured = $presenter->getCapturedResponse();
+	Assert::type(RedirectResponse::class, $captured);
+	assert($captured instanceof RedirectResponse);
+
+	Assert::same('/form', $captured->getUrl());
+	Assert::same(303, $captured->getCode());
+
+	$session->close();
+	session_id('');
+});
+
+Toolkit::test(function (): void {
+	prepareSessionEnvironment();
+
+	$request = new Request(
+		new UrlScript('https://example.com/form', '/index.php'),
+		headers: [
+			'X-Inertia' => 'true',
+			'X-Inertia-Version' => 'v1',
+			'X-Inertia-Error-Bag' => 'createUser',
+		],
+	);
+
+	[$presenter, , , $session] = createPresenter($request, new Inertia(version: 'v1'));
+	$presenter->flashInertiaErrors(['email' => 'Required']);
+
+	Assert::exception(fn () => $presenter->runInertia('Users/Create'), AbortException::class);
+
+	$captured = $presenter->getCapturedResponse();
+	Assert::type(JsonResponse::class, $captured);
+	assert($captured instanceof JsonResponse);
+	$payload = $captured->getPayload();
+	Assert::same(['createUser' => ['email' => 'Required']], $payload->props['errors']);
+
+	$session->close();
+	session_id('');
+});

--- a/tests/Fixtures/Inertia/TestHttpResponse.php
+++ b/tests/Fixtures/Inertia/TestHttpResponse.php
@@ -1,0 +1,128 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\Fixtures\Inertia;
+
+use Nette\Http\IResponse;
+
+final class TestHttpResponse implements IResponse
+{
+
+	public string $cookieDomain = '';
+
+	public string $cookiePath = '/';
+
+	public bool $cookieSecure = false;
+
+	private int $code = self::S200_OK;
+
+	/** @var array<string, string> */
+	private array $headers = [];
+
+	/** @var array<string, list<string>> */
+	private array $addedHeaders = [];
+
+	public function setCode(int $code, ?string $reason = null): static
+	{
+		$this->code = $code;
+
+		return $this;
+	}
+
+	public function getCode(): int
+	{
+		return $this->code;
+	}
+
+	public function setHeader(string $name, ?string $value): static
+	{
+		if ($value === null) {
+			unset($this->headers[$name]);
+
+			return $this;
+		}
+
+		$this->headers[$name] = $value;
+
+		return $this;
+	}
+
+	public function addHeader(string $name, string $value): static
+	{
+		$this->addedHeaders[$name] ??= [];
+		$this->addedHeaders[$name][] = $value;
+
+		return $this;
+	}
+
+	public function deleteHeader(string $name): static
+	{
+		unset($this->headers[$name], $this->addedHeaders[$name]);
+
+		return $this;
+	}
+
+	public function getHeader(string $header): ?string
+	{
+		return $this->headers[$header] ?? null;
+	}
+
+	/**
+	 * @return array<string, string>
+	 */
+	public function getHeaders(): array
+	{
+		return $this->headers;
+	}
+
+	public function setContentType(string $type, ?string $charset = null): static
+	{
+		return $this->setHeader('Content-Type', $type . ($charset !== null ? '; charset=' . $charset : ''));
+	}
+
+	public function redirect(string $url, int $code = self::S302_Found): void
+	{
+		$this->setCode($code);
+		$this->setHeader('Location', $url);
+	}
+
+	public function setExpiration(?string $expire): static
+	{
+		return $this;
+	}
+
+	public function isSent(): bool
+	{
+		return false;
+	}
+
+	public function setCookie(string $name, string $value, mixed $expire, ?string $path = null, ?string $domain = null, ?bool $secure = null, ?bool $httpOnly = null, ?string $sameSite = null): static
+	{
+		return $this;
+	}
+
+	public function deleteCookie(string $name, ?string $path = null, ?string $domain = null, ?bool $secure = null): static
+	{
+		return $this;
+	}
+
+	public function getCookie(string $name): ?string
+	{
+		return null;
+	}
+
+	public function sendAsFile(string $fileName): static
+	{
+		return $this;
+	}
+
+	public function write(string $s): void
+	{
+		// noop
+	}
+
+	public function flush(): void
+	{
+		// noop
+	}
+
+}

--- a/tests/Fixtures/Inertia/TestPresenter.php
+++ b/tests/Fixtures/Inertia/TestPresenter.php
@@ -1,0 +1,82 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\Fixtures\Inertia;
+
+use Contributte\UI\Inertia\Presenter\TInertiaPresenter;
+use Nette\Application\AbortException;
+use Nette\Application\Response;
+use Nette\Application\UI\Presenter;
+
+final class TestPresenter extends Presenter
+{
+
+	use TInertiaPresenter;
+
+	private ?Response $capturedResponse = null;
+
+	/** @var array<string, mixed> */
+	private array $sharedProps = [];
+
+	/**
+	 * @param array<string, mixed> $props
+	 */
+	public function runInertia(string $component, array $props = []): void
+	{
+		$this->inertia($component, $props);
+	}
+
+	/**
+	 * @param array<string, mixed>|string $key
+	 */
+	public function shareInertia(array|string $key, mixed $value = null): void
+	{
+		$this->inertiaShare($key, $value);
+	}
+
+	/**
+	 * @param array<string, mixed> $errors
+	 */
+	public function flashInertiaErrors(array $errors, ?string $bag = null): void
+	{
+		$this->inertiaErrors($errors, $bag);
+	}
+
+	public function triggerRedirect(string $url): void
+	{
+		$this->redirectUrl($url);
+	}
+
+	public function triggerLocation(string $url): void
+	{
+		$this->inertiaLocation($url);
+	}
+
+	public function getCapturedResponse(): ?Response
+	{
+		return $this->capturedResponse;
+	}
+
+	/**
+	 * @param array<string, mixed> $props
+	 */
+	public function setSharedProps(array $props): void
+	{
+		$this->sharedProps = $props;
+	}
+
+	public function sendResponse(Response $response): void
+	{
+		$this->capturedResponse = $response;
+
+		throw new AbortException();
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	protected function getInertiaSharedProps(): array
+	{
+		return $this->sharedProps;
+	}
+
+}


### PR DESCRIPTION
## What changed
- add a reusable `src/Inertia` module with page serialization, request/version handling, partial reload filtering, session-backed errors, Latte helpers, and `TInertiaPresenter`
- wire the feature through `InertiaExtension`, add protocol-focused `.phpt` coverage, and document package usage
- keep the integration frontend-agnostic so consumers can pair it with their own Vue/React/Svelte runtime

## Why
- Nette applications need a protocol-correct Inertia adapter that lives in `contributte/ui` rather than ad-hoc app code
- this provides the foundation needed to demonstrate and adopt Inertia cleanly in downstream Contributte skeletons
